### PR TITLE
Fix for 'undefined' YouTube videos when no result found

### DIFF
--- a/eksin.user.js
+++ b/eksin.user.js
@@ -122,8 +122,10 @@ chrome.storage.sync.get({
           if (response.items) {
                 $.each(response.items, function (i, data) {
                     var video_id = data.id.videoId;
-                    var video_frame = "<iframe width='100%' height='360' src='https://www.youtube.com/embed/"+ video_id + "?feature=player_embedded' frameborder='0' allowfullscreen></iframe>";
-                    if ($("#videos")) $("#videos").html(video_frame);
+                    if(video_id){ //undefined check
+                      var video_frame = "<h2 id=\"videolar\">konulu youtube</h2><iframe width='100%' height='360' src='https://www.youtube.com/embed/"+ video_id + "?feature=player_embedded' frameborder='0' allowfullscreen></iframe>";
+                      if ($("#videos")) $("#videos").html(video_frame);
+                    }
                 }); //.each
             } //if.response
         } //.sucess


### PR DESCRIPTION
Bazı spesifik tanımlı, uzun isimli vb. başlıklar için YouTube'da sonuç bulunamıyor, ama iframe yine de YouTube playerı açıp id olarak da undefined yazıyordu. Bunu kontrol eden küçük bir if ekledim, böylece eğer YouTube'da sonuç bulunmazsa 59saniye videosuna dokunmuyor.

59saniye ile YouTube'un ayırt edilebilmesi için de YouTube videolarının başına "konulu youtube" metni ekledim.
