### PR TITLE
Konulu kapatılmışsa YouTube'da arama yapmaya gerek yok.

### DIFF
--- a/eksin.user.js
+++ b/eksin.user.js
@@ -106,10 +106,10 @@ gozcu.observe(
 Konulu videolar'ı youtube ile değiştir
 */
 chrome.storage.sync.get({
-  youtube: false
+  youtube: false, konulu: false
 }, function(items) {
 
-  if (items.youtube) {
+  if (items.konulu && items.youtube) {
     var search_input = $("#title").text();
 
     var yt_url =  "https://www.googleapis.com/youtube/v3/search?safeSearch=none&part=snippet&q="+ encodeURIComponent(search_input) +"&relevanceLanguage=tr&maxResults=1&key=AIzaSyBrQhJDh900EamsDLWZH6kQm_9Dc1AqcX8"


### PR DESCRIPTION
Kullanıcı eğer Konulu Videoları Göster seçeneğini kapatmışsa videoları YouTube ile değiştirmenin kullanıcıya herhangi bir katkısı olmuyor. Bu durumda YouTube'da arama yapmaya da gerek kalmıyor. 

Konulu videoları YouTube videoları ile değiştiren kısımdaki if kontrollerine konulu değişkenini de ekledim. Konulu kapalıyken YouTube açık ise arkaplanda arama&değiştirme yapılmıyor. Hem sayfa kullanıcıya daha hızlı yükleniyor, hem arama yapılan keyin kullanım sınırı zorlanmamış oluyor.
