### PR TITLE
Başlıklarda yukarıda büyük görüntülenen videolar için güncelleme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Konulu videolar genellikle gereksiz içerikler, lüzumsuz önerilerle karşımı
 - 24saat ile erişilen başlıklarda, trollere eklediğiniz yazarların entryleri de görüntüleniyor.
 
 ### Sürüm değişiklikleri
+- **v1.3.8**:
+ - Bazı başlıklarda yukarıda gösterilen videoları da YouTube ile değiştir. [3](https://github.com/expeditor/eksi-reaktor/pull/3)
 - **v1.3.7**:
  - [kyzn](https://github.com/kyzn)'in youtube-konulu düzeltmeleri. [1](https://github.com/expeditor/eksi-reaktor/pull/1) [2](https://github.com/expeditor/eksi-reaktor/pull/2)
  - Alışılmış olarak sıkça kullanılan badi konumunun yerine geçtiğinden dolayı 24saat'i badinin sağına aldım.

--- a/eksin.user.js
+++ b/eksin.user.js
@@ -130,7 +130,11 @@ chrome.storage.sync.get({
                     var video_id = data.id.videoId;
                     if(video_id){ //undefined check
                       var video_frame = "<h2 id=\"videolar\">konulu youtube</h2><iframe width='100%' height='360' src='https://www.youtube.com/embed/"+ video_id + "?feature=player_embedded' frameborder='0' allowfullscreen></iframe>";
+                      var video_upper_frame = "<iframe width='100%' height='315' src='https://www.youtube.com/embed/"+ video_id + "?feature=player_embedded' frameborder='0' allowfullscreen></iframe>";
+                      //Convert videos on right side
                       if ($("#videos")) $("#videos").html(video_frame);
+                      //Convert videos that appear at top
+                      if ($("#video")) $("#video").html(video_upper_frame);
                     }
                 }); //.each
             } //if.response

--- a/eksin.user.js
+++ b/eksin.user.js
@@ -34,9 +34,13 @@ chrome.storage.sync.get({
 function odaklan(konulu, solFrame, topBar, ustMenu) {
     /* Konulu videolar göster/gizle */
     if (konulu == false) {
-      if (document.getElementById('videos')) {
+      if (document.getElementById('videos')) { //right sidebar
         document.getElementById('videos').style.display = "none";
       }
+      if (document.getElementById('video')) { //above entries
+        document.getElementById('video').style.display = "none";
+      }
+
     }
 
     if (solFrame == false) {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "author": "expeditor",
   "homepage_url": "https://github.com/expeditor/eksi-reaktor",
   "description": "Ekşi sözlük için bağzı aparatlar",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "permissions": [
     "*://eksisozluk.com/*",
      "storage",


### PR DESCRIPTION
Bazı başlıklarda (örneğin [şurada](https://eksisozluk.com/h-mdeki-balmain-izdihami--4956138)) başlığın en tepesinde 59saniye videosu görüntüleniyor. Sağ tarafta gösterilen diğer videolar `<section id="videos">` içindeyken yukarıdaki bölüm `<div id="video">` şeklinde tanımlanmış, dolayısıyla koddaki "videos" düzenlemeleri yukarıdaki videolara etki etmiyordu.

Normal hali şu şekilde:

![screen shot 2015-11-03 at 5 18 54 pm](https://cloud.githubusercontent.com/assets/1781335/10926860/d8d329e4-824f-11e5-9db3-7289120700cb.png)

YouTube olsun seçildiğinde şu hale geliyor:

![screen shot 2015-11-03 at 5 19 27 pm](https://cloud.githubusercontent.com/assets/1781335/10926867/e6f589d6-824f-11e5-8f18-e18fcebf17ad.png)

Konulu videoları göster kapatıldığında artık "video" da aranıyor ve gizleniyor.

![screen shot 2015-11-03 at 5 19 45 pm](https://cloud.githubusercontent.com/assets/1781335/10926874/ed51a116-824f-11e5-99da-4c350e09addd.png)

Bu sefer ben de master branchinde çalıştım, fix- diye yeni bir branch açsam belki daha temiz olacaktı ama çok geç aklıma geldi. 

Bende sorunsuz çalıştı ama isterseniz siz de bir deneyin.
